### PR TITLE
Fix 240611

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,20 @@
 /data/
 /.lando.yml
 *.cache.php
-/plugin/lightstats/
-/plugin/mdeditor/
-/plugin/highlight/
-/plugin/download/
-/plugin/home/
+
+# plugins
+!/plugin/antispam/
+!/plugin/blog/
+!/plugin/configmanager/
+!/plugin/contact/
+!/plugin/filemanager/
+!/plugin/galerie/
+/plugin/
+
+# themes
+!/theme/default/
+/theme/
+
+#editor
 .vscode/
+

--- a/admin/layout.tpl
+++ b/admin/layout.tpl
@@ -24,7 +24,7 @@
 					<div class="main_nav" role="navigation" aria-label="{{ Lang.core-nav-admin }}">
 						<ul id="navigation">
 							<li id="nav-change-container">
-								<a role="button" href="#" onclick="changeMainNav()">
+								<a role="button" href="#" onclick="return changeMainNav()">
 									<i title="{{ Lang.admin-change-sidebar-width }}" id="nav-icon-grow"></i>
 								</a>
 							</li>

--- a/admin/scripts.js
+++ b/admin/scripts.js
@@ -6,7 +6,7 @@
  * @author Frédéric Kaplon <frederic.kaplon@me.com>
  * @author Florent Fortat <florent.fortat@maxgun.fr>
  * @author ShevAbam <me@shevarezo.fr>
- * 
+ *
  * @package 299Ko https://github.com/299Ko/299ko
  */
 
@@ -16,7 +16,7 @@
  * @license MIT licensed
  *
  * Copyright (C) 2018 Varun A P
- */ 
+ */
 !function(t,o){"object"==typeof module&&module.exports?module.exports=o():t.Toastify=o()}(this,function(t){var o=function(t){return new o.lib.init(t)};function i(t,o){return o.offset[t]?isNaN(o.offset[t])?o.offset[t]:o.offset[t]+"px":"0px"}function s(t,o){return!!t&&"string"==typeof o&&!!(t.className&&t.className.trim().split(/\s+/gi).indexOf(o)>-1)}return o.defaults={oldestFirst:!0,text:"Toastify is awesome!",node:void 0,duration:4e3,selector:void 0,callback:function(){},destination:void 0,newWindow:!1,close:true,gravity:"toastify-top",positionLeft:!1,position:"",backgroundColor:"",avatar:"",className:"",stopOnFocus:!0,onClick:function(){},offset:{x:0,y:0},escapeMarkup:!0,ariaLive:"polite",style:{background:""}},o.lib=o.prototype={toastify:"1.12.0",constructor:o,init:function(t){return t||(t={}),this.options={},this.toastElement=null,this.options.text=t.text||o.defaults.text,this.options.node=t.node||o.defaults.node,this.options.duration=0===t.duration?0:t.duration||o.defaults.duration,this.options.selector=t.selector||o.defaults.selector,this.options.callback=t.callback||o.defaults.callback,this.options.destination=t.destination||o.defaults.destination,this.options.newWindow=t.newWindow||o.defaults.newWindow,this.options.close=t.close||o.defaults.close,this.options.gravity="bottom"===t.gravity?"toastify-bottom":o.defaults.gravity,this.options.positionLeft=t.positionLeft||o.defaults.positionLeft,this.options.position=t.position||o.defaults.position,this.options.backgroundColor=t.backgroundColor||o.defaults.backgroundColor,this.options.avatar=t.avatar||o.defaults.avatar,this.options.className=t.className||o.defaults.className,this.options.stopOnFocus=void 0===t.stopOnFocus?o.defaults.stopOnFocus:t.stopOnFocus,this.options.onClick=t.onClick||o.defaults.onClick,this.options.offset=t.offset||o.defaults.offset,this.options.escapeMarkup=void 0!==t.escapeMarkup?t.escapeMarkup:o.defaults.escapeMarkup,this.options.ariaLive=t.ariaLive||o.defaults.ariaLive,this.options.style=t.style||o.defaults.style,t.backgroundColor&&(this.options.style.background=t.backgroundColor),this},buildToast:function(){if(!this.options)throw"Toastify is not initialized";var t=document.createElement("div");for(var o in t.className="toastify on "+this.options.className,this.options.position?t.className+=" toastify-"+this.options.position:!0===this.options.positionLeft?(t.className+=" toastify-left",console.warn("Property `positionLeft` will be depreciated in further versions. Please use `position` instead.")):t.className+=" toastify-right",t.className+=" "+this.options.gravity,this.options.backgroundColor&&console.warn('DEPRECATION NOTICE: "backgroundColor" is being deprecated. Please use the "style.background" property.'),this.options.style)t.style[o]=this.options.style[o];if(this.options.ariaLive&&t.setAttribute("aria-live",this.options.ariaLive),this.options.node&&this.options.node.nodeType===Node.ELEMENT_NODE)t.appendChild(this.options.node);else if(this.options.escapeMarkup?t.innerText=this.options.text:t.innerHTML=this.options.text,""!==this.options.avatar){var s=document.createElement("img");s.src=this.options.avatar,s.className="toastify-avatar","left"==this.options.position||!0===this.options.positionLeft?t.appendChild(s):t.insertAdjacentElement("afterbegin",s)}if(!0===this.options.close){var e=document.createElement("button");e.type="button",e.setAttribute("aria-label","Close"),e.className="toast-close",e.innerHTML="<i class='fa-solid fa-xmark'></i>",e.addEventListener("click",(function(t){t.stopPropagation(),this.removeElement(this.toastElement),window.clearTimeout(this.toastElement.timeOutValue)}).bind(this));var n=window.innerWidth>0?window.innerWidth:screen.width;("left"==this.options.position||!0===this.options.positionLeft)&&n>360?t.insertAdjacentElement("afterbegin",e):t.appendChild(e)}if(this.options.stopOnFocus&&this.options.duration>0){var a=this;t.addEventListener("mouseover",function(o){window.clearTimeout(t.timeOutValue)}),t.addEventListener("mouseleave",function(){t.timeOutValue=window.setTimeout(function(){a.removeElement(t)},a.options.duration)})}if(void 0!==this.options.destination&&t.addEventListener("click",(function(t){t.stopPropagation(),!0===this.options.newWindow?window.open(this.options.destination,"_blank"):window.location=this.options.destination}).bind(this)),"function"==typeof this.options.onClick&&void 0===this.options.destination&&t.addEventListener("click",(function(t){t.stopPropagation(),this.options.onClick()}).bind(this)),"object"==typeof this.options.offset){var l=i("x",this.options),r=i("y",this.options),p="left"==this.options.position?l:"-"+l,d="toastify-top"==this.options.gravity?r:"-"+r;t.style.transform="translate("+p+","+d+")"}return t},showToast:function(){if(this.toastElement=this.buildToast(),!(t="string"==typeof this.options.selector?document.getElementById(this.options.selector):this.options.selector instanceof HTMLElement||"undefined"!=typeof ShadowRoot&&this.options.selector instanceof ShadowRoot?this.options.selector:document.body))throw"Root element is not defined";var t,i=o.defaults.oldestFirst?t.firstChild:t.lastChild;return t.insertBefore(this.toastElement,i),o.reposition(),this.options.duration>0&&(this.toastElement.timeOutValue=window.setTimeout((function(){this.removeElement(this.toastElement)}).bind(this),this.options.duration)),this},hideToast:function(){this.toastElement.timeOutValue&&clearTimeout(this.toastElement.timeOutValue),this.removeElement(this.toastElement)},removeElement:function(t){t.className=t.className.replace(" on",""),window.setTimeout((function(){this.options.node&&this.options.node.parentNode&&this.options.node.parentNode.removeChild(this.options.node),t.parentNode&&t.parentNode.removeChild(t),this.options.callback.call(t),o.reposition()}).bind(this),400)}},o.reposition=function(){for(var t,o={top:15,bottom:15},i={top:15,bottom:15},e={top:15,bottom:15},n=document.getElementsByClassName("toastify"),a=0;a<n.length;a++){t=!0===s(n[a],"toastify-top")?"toastify-top":"toastify-bottom";var l=n[a].offsetHeight;t=t.substr(9,t.length-1),(window.innerWidth>0?window.innerWidth:screen.width)<=360?(n[a].style[t]=e[t]+"px",e[t]+=l+15):!0===s(n[a],"toastify-left")?(n[a].style[t]=o[t]+"px",o[t]+=l+15):(n[a].style[t]=i[t]+"px",i[t]+=l+15)}return this},o.lib.init.prototype=o.lib,o});
 
 document.addEventListener("DOMContentLoaded", function () {
@@ -31,7 +31,7 @@ document.addEventListener("DOMContentLoaded", function () {
         }, 8000 + index * 8000);
 
     });
-    
+
     document.querySelectorAll('.tabs-container').forEach(x => tabify(x));
 
     // Login : btn Quitter redirection
@@ -40,7 +40,7 @@ document.addEventListener("DOMContentLoaded", function () {
             document.location.href = this.getAttribute('rel');
         });
     }
-    
+
     window.addEventListener("resize", resizeListener);
     resizeListener();
 
@@ -67,6 +67,7 @@ function changeMainNav() {
     var nav = document.querySelector('#adminNav');
     nav.classList.toggle('withoutText');
     nav.classList.add('manuallyChanged');
+    return false;
 }
 
 function fadeOut(el) {
@@ -117,8 +118,8 @@ function tabify(element){
 }
 
 
-/* plain JS slideToggle https://github.com/ericbutler555/plain-js-slidetoggle 
- * 
+/* plain JS slideToggle https://github.com/ericbutler555/plain-js-slidetoggle
+ *
  * var sidebar = document.querySelector('#sidebar');
  * sidebar.slideToggle(400);
  */
@@ -141,7 +142,7 @@ HTMLElement.prototype.slideToggle = function (t, e) {
 
 /*
  * Get Next Sibling of an element, with or without selector
- * 
+ *
  * var el = getNextSibling(element, 'div.class');
  */
 

--- a/common/categories/CategoriesManager.php
+++ b/common/categories/CategoriesManager.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 abstract class CategoriesManager {
 

--- a/common/categories/Category.php
+++ b/common/categories/Category.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 abstract class Category implements JsonSerializable {
 

--- a/common/categories/template/checkboxCategories.php
+++ b/common/categories/template/checkboxCategories.php
@@ -6,7 +6,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 switch ($catDisplay) {
     case 'root':

--- a/common/categories/template/listCategories.php
+++ b/common/categories/template/listCategories.php
@@ -6,7 +6,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 switch ($catDisplay) {
     case 'root':

--- a/common/categories/template/selectCategory.php
+++ b/common/categories/template/selectCategory.php
@@ -6,7 +6,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 switch ($catDisplay) {
     case 'root':

--- a/common/categories/template/selectOneCategory.php
+++ b/common/categories/template/selectOneCategory.php
@@ -6,7 +6,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 switch ($catDisplay) {
     case 'root':

--- a/common/common.php
+++ b/common/common.php
@@ -20,16 +20,13 @@ include_once ROOT . 'common/config.php';
 
 // Autoload class in COMMON directory
 spl_autoload_register(function ($class) {
-	$className = strtolower($class);
+	$pattern = '#^' . $class . '(?:\.class)?\.php$#i';
 	$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(COMMON));
-	foreach ($iterator as $file)
+	foreach ($iterator as $fileInfo) // $fileInfo is a SplFileInfo object
 	{
-		if ($file->isFile() && pathinfo($file, PATHINFO_EXTENSION) === 'php') {
-			$fileName = strtolower($file->getFilename());
-			if ($fileName === $className . '.php' || $fileName === $className . '.class.php') {
-				include_once($file);
-				break;
-			}
+		if ($fileInfo->isFile() && preg_match($pattern , $fileInfo->getFileName())) {
+			include_once $fileInfo; // as $fileInfo->__toString()
+			return;
 		}
 	}
 });

--- a/common/common.php
+++ b/common/common.php
@@ -12,7 +12,7 @@
  */
 
 session_start();
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 define('BASE_PATH', rtrim(dirname($_SERVER['SCRIPT_NAME']), '/'));
 

--- a/common/common.php
+++ b/common/common.php
@@ -21,10 +21,10 @@ include_once ROOT . 'common/config.php';
 // Autoload class in COMMON directory
 spl_autoload_register(function ($class) {
 	$pattern = '#^' . $class . '(?:\.class)?\.php$#i';
-	$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(COMMON));
+	$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(COMMON, FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::SKIP_DOTS));
 	foreach ($iterator as $fileInfo) // $fileInfo is a SplFileInfo object
 	{
-		if ($fileInfo->isFile() && preg_match($pattern , $fileInfo->getFileName())) {
+		if (preg_match($pattern , $fileInfo->getFileName())) {
 			include_once $fileInfo; // as $fileInfo->__toString()
 			return;
 		}

--- a/common/common.php
+++ b/common/common.php
@@ -7,13 +7,16 @@
  * @author Maxence Cauderlier <mx.koder@gmail.com>
  * @author Frédéric Kaplon <frederic.kaplon@me.com>
  * @author Florent Fortat <florent.fortat@maxgun.fr>
- * 
+ *
  * @package 299Ko https://github.com/299Ko/299ko
  */
+
 session_start();
 defined('ROOT') or exit('No direct script access allowed');
 
-include_once(ROOT . 'common/config.php');
+define('BASE_PATH', rtrim(dirname($_SERVER['SCRIPT_NAME']), '/'));
+
+include_once ROOT . 'common/config.php';
 
 // Autoload class in COMMON directory
 spl_autoload_register(function ($class) {
@@ -40,7 +43,7 @@ foreach ($pluginsManager->getPlugins() as $plugin) {
         $plugin->loadLangFile();
         $plugin->loadRoutes();
 		if ($plugin->getLibFile() !== false) {
-			include_once($plugin->getLibFile());
+			include_once $plugin->getLibFile();
 		}
         foreach ($plugin->getHooks() as $name => $function) {
             $core->addHook($name, $function);

--- a/common/config.php
+++ b/common/config.php
@@ -7,20 +7,23 @@
  * @author Maxence Cauderlier <mx.koder@gmail.com>
  * @author Frédéric Kaplon <frederic.kaplon@me.com>
  * @author Florent Fortat <florent.fortat@maxgun.fr>
- * 
+ *
  * @package 299Ko https://github.com/299Ko/299ko
  */
- 
-define('VERSION', '2.0.0');
-define('COMMON', ROOT . 'common/');
-define('DATA', ROOT . 'data/');
-define('UPLOAD', ROOT . 'data/upload/');
-define('DATA_PLUGIN', ROOT . 'data/plugin/');
-define('THEMES', ROOT . 'theme/');
-define('PLUGINS', ROOT . 'plugin/');
-define('ADMIN_PATH', ROOT . 'admin/');
-define('FONTICON', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css');
-define('FANCYCSS', "https://cdnjs.cloudflare.com/ajax/libs/fancyapps-ui/4.0.31/fancybox.min.css");
-define("FANCYJS", "https://cdnjs.cloudflare.com/ajax/libs/fancyapps-ui/4.0.31/fancybox.umd.min.js");
-if (file_exists(DATA . 'key.php'))
-    include(DATA . 'key.php');
+
+const VERSION = '2.0.0';
+const COMMON = ROOT . 'common/';
+const DATA = ROOT . 'data/';
+const UPLOAD = ROOT . 'data/upload/';
+const DATA_PLUGIN = ROOT . 'data/plugin/';
+const THEMES = ROOT . 'theme/';
+const PLUGINS = ROOT . 'plugin/';
+const ADMIN_PATH = ROOT . 'admin/';
+const FONTICON = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css';
+const FANCYCSS = 'https://cdnjs.cloudflare.com/ajax/libs/fancyapps-ui/4.0.31/fancybox.min.css';
+const FANCYJS = 'https://cdnjs.cloudflare.com/ajax/libs/fancyapps-ui/4.0.31/fancybox.umd.min.js';
+
+$filename = DATA . 'key.php';
+if (file_exists($filename)) {
+    include $filename;
+}

--- a/common/controllers/AdminController.php
+++ b/common/controllers/AdminController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class AdminController extends Controller {
 

--- a/common/controllers/Controller.php
+++ b/common/controllers/Controller.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 abstract class Controller {
     

--- a/common/controllers/CoreController.php
+++ b/common/controllers/CoreController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class CoreController extends Controller
 {

--- a/common/controllers/PublicController.php
+++ b/common/controllers/PublicController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class PublicController extends Controller {
 

--- a/common/core.class.php
+++ b/common/core.class.php
@@ -10,7 +10,10 @@
  *
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+
+const ACCESS_DENIED = 'Access denied !';
+
+defined('ROOT') or exit('Access denied!');
 
 class core
 {
@@ -361,7 +364,7 @@ class core
             ob_start();
             echo '<?php' . PHP_EOL;
 ?>
-defined('ROOT') or exit('Direct script access forbidden !');
+defined('ROOT') or exit('<?= ACCESS_DENIED ?>');
 const KEY = '<?= $key ?>';
 <?php
             if(!@file_put_contents($filename, ob_get_clean() . PHP_EOL, 0604)) {

--- a/common/editor.php
+++ b/common/editor.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 /**
  * Editor is a class to simplify how plugins works with textarea and the editor

--- a/common/lang.class.php
+++ b/common/lang.class.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class lang {
     

--- a/common/plugin.class.php
+++ b/common/plugin.class.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class plugin {
 

--- a/common/pluginsManager.class.php
+++ b/common/pluginsManager.class.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class pluginsManager {
 

--- a/common/responses/AdminResponse.php
+++ b/common/responses/AdminResponse.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class AdminResponse extends Response {
 

--- a/common/responses/ApiResponse.php
+++ b/common/responses/ApiResponse.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class ApiResponse extends Response
 {

--- a/common/responses/PublicResponse.php
+++ b/common/responses/PublicResponse.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class PublicResponse extends Response {
 

--- a/common/responses/Response.php
+++ b/common/responses/Response.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 abstract class Response {
 

--- a/common/responses/StringResponse.php
+++ b/common/responses/StringResponse.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class StringResponse extends Response {
 

--- a/common/router/router.php
+++ b/common/router/router.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class router extends AltoRouter {
 

--- a/common/show.class.php
+++ b/common/show.class.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class show {
 

--- a/common/template.class.php
+++ b/common/template.class.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 /**
  * Simple lightweight template parser.

--- a/common/util.class.php
+++ b/common/util.class.php
@@ -7,7 +7,7 @@
  * @author Maxence Cauderlier <mx.koder@gmail.com>
  * @author Frédéric Kaplon <frederic.kaplon@me.com>
  * @author Florent Fortat <florent.fortat@maxgun.fr>
- * 
+ *
  * @package 299Ko https://github.com/299Ko/299ko
  */
 defined('ROOT') or exit('Access denied!');
@@ -38,7 +38,7 @@ class util
     /**
      * Truncate an HTML content and keep only the <p> and <br> tags
      * It save the new lines and dont cut on a word
-     * 
+     *
      * @param  string $str      Content to truncate
      * @param  int    $length   Number of characters to keep
      * @param  string $add      Text to add after the content if truncated
@@ -78,9 +78,7 @@ class util
 
     public static function isEmail($email)
     {
-        if (preg_match("/^[_a-zA-Z0-9-]+(\.[_a-zA-Z0-9-]+)*@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,4}$/", $email))
-            return true;
-        return false;
+		return (filter_var($email, FILTER_VALIDATE_EMAIL) === false) ? false : true;
     }
 
     ## Envoie un email
@@ -108,7 +106,7 @@ class util
 
     /**
      * List a directory and return an array with files and folders (separated). This function is not recursive
-     * 
+     *
      * @param string $folder Path to scan
      * @param array $not Array of files to exclude
      * @return array $data['dir] : Directories / $data['file'] : Files
@@ -240,7 +238,7 @@ class util
 
     /**
      * Build absolute URL with siteURL saved in config.json
-     * 
+     *
      * @param  string URI
      * @param  bool   is Admin location
      * @return string URL
@@ -261,7 +259,7 @@ class util
 
     /**
      * Return current page URL
-     * 
+     *
      * @return string
      */
     public static function getCurrentURL()
@@ -374,7 +372,7 @@ class util
             }
             $current_level = $level;
         }
-        
+
         if (!isset($level)) {
             // No heading
             return false;

--- a/common/util.class.php
+++ b/common/util.class.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class util
 {

--- a/index.php
+++ b/index.php
@@ -7,12 +7,13 @@
  * @author Maxence Cauderlier <mx.koder@gmail.com>
  * @author Frédéric Kaplon <frederic.kaplon@me.com>
  * @author Florent Fortat <florent.fortat@maxgun.fr>
- * 
+ *
  * @package 299Ko https://github.com/299Ko/299ko
  */
-define('ROOT', './');
-define('BASE_PATH', substr(__DIR__, strlen($_SERVER['DOCUMENT_ROOT'])));
-include_once(ROOT . 'common/common.php');
+
+const ROOT = './';
+
+include_once ROOT . 'common/common.php';
 
 if (!$core->isInstalled()) {
     header('location:' . ROOT . 'install.php');
@@ -20,6 +21,7 @@ if (!$core->isInstalled()) {
 }
 
 define('IS_LOGGED', UsersManager::isLogged());
+
 // For futures versions
 define('IS_ADMIN', IS_LOGGED);
 

--- a/install.php
+++ b/install.php
@@ -6,16 +6,20 @@
  * @author Maxence Cauderlier <mx.koder@gmail.com>
  * @author Frédéric Kaplon <frederic.kaplon@me.com>
  * @author Florent Fortat <florent.fortat@maxgun.fr>
- * 
+ *
  * @package 299Ko https://github.com/299Ko/299ko
  */
+
 ini_set('display_errors', 1);
-define('ROOT', './');
-define('BASE_PATH', substr(__DIR__, strlen($_SERVER['DOCUMENT_ROOT'])));
-include_once(ROOT . 'common/config.php');
-include_once(ROOT . 'common/common.php');
-if (file_exists(DATA . 'config.json'))
+
+const ROOT = './';
+
+include_once ROOT . 'common/common.php';
+
+if (file_exists(DATA . 'config.json')) {
     die('A config file is already exist');
+}
+
 $core = core::getInstance();
 $pluginsManager = pluginsManager::getInstance();
 $url = core::getInstance()->makeSiteUrl() . '/install.php';
@@ -97,7 +101,7 @@ if (count($_POST) > 0) {
     <head>
         <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=5">
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>299ko - <?php echo lang::get('install-installation'); ?></title>	
+        <title>299ko - <?php echo lang::get('install-installation'); ?></title>
         <link rel="stylesheet" href="admin/styles.css" media="all">
         <link rel="stylesheet" href="<?php echo FONTICON; ?>" />
     </head>
@@ -148,9 +152,9 @@ if (count($_POST) > 0) {
                 echo lang::get('install-please-check-errors');
             } else {
                 ?>
-                <form method="post" action="">   
+                <form method="post" action="">
                     <?php echo '<h3>'.lang::get('install-please-fill-fields').'</h3>';
-                    ?>          
+                    ?>
                     <p><label for="lang-select"><?php echo lang::get('install-lang-choice'); ?></label>
                     <select name="lang-select" id="lang-select" onchange="langChange()">
                         <?php
@@ -179,7 +183,7 @@ if (count($_POST) > 0) {
                     </form>
                     <footer><a target="_blank" href="https://github.com/299ko/"><?php echo lang::get('site-just-using', VERSION); ?></a>
                     </footer>
-                
+
                 <?php
             }
             ?>

--- a/install.php
+++ b/install.php
@@ -94,16 +94,16 @@ if (count($_POST) > 0) {
         die();
     }
 }
-?>
 
+?>
 <!doctype html>
-<html lang="fr">
+<html lang="<?= lang::getLocale() ?>">
     <head>
         <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=5">
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>299ko - <?php echo lang::get('install-installation'); ?></title>
+        <title>299ko - <?= lang::get('install-installation') ?></title>
         <link rel="stylesheet" href="admin/styles.css" media="all">
-        <link rel="stylesheet" href="<?php echo FONTICON; ?>" />
+        <link rel="stylesheet" href="<?= FONTICON ?>" />
     </head>
 
     <body class="login">
@@ -112,89 +112,103 @@ if (count($_POST) > 0) {
         </div>
         <section id="install">
             <header>
-                <h1 class="text-center"><?php echo lang::get('install-installation'); ?></h1>
+                <h1 class="text-center"><?= lang::get('install-installation'); ?></h1>
             </header>
-            <?php
-            if ($errorPHP) {
-                echo '<div class="msg error">';
-                echo lang::get('install-php-version-error', (float) substr(phpversion(), 0, 3), $minPHPVersion);
-                echo '</div>';
-            } else {
-                echo '<div class="msg success">';
-                echo lang::get('install-php-version-ok', $minPHPVersion);
-                echo '</div>';
-            }
+<?php
+	if ($errorPHP) {
+?>
+			<div class="msg error">
+                <?= lang::get('install-php-version-error', (float) substr(phpversion(), 0, 3), $minPHPVersion) ?>
+            </div>
+<?php
+	} else {
+?>
+            <div class="msg success">
+                <?= lang::get('install-php-version-ok', $minPHPVersion) ?>
+            </div>
+<?php
+    }
 
-            if ($errorRewrite === 'CGI') {
-                echo '<div class="msg warning">';
-                echo lang::get('install-php-rewrite-cgi');
-                echo '</div>';
-            } elseif ($errorRewrite) {
-                echo '<div class="msg error">';
-                echo lang::get('install-php-rewrite-error');
-                echo '</div>';
-            } else {
-                echo '<div class="msg success">';
-                echo lang::get('install-php-rewrite-ok');
-                echo '</div>';
-            }
+	if ($errorRewrite === 'CGI') {
+?>
+			<div class="msg warning">
+                <?= lang::get('install-php-rewrite-cgi') ?>
+			</div>
+<?php
+    } elseif ($errorRewrite) {
+?>
+            <div class="msg error">
+                <?= lang::get('install-php-rewrite-error') ?>
+            </div>
+<?php
+    } else {
+?>
+			<div class="msg success">';
+				<?= lang::get('install-php-rewrite-ok') ?>
+            </div>
+<?php
+    }
 
-            if ($errorDataWrite) {
-                echo '<div class="msg error">';
-                echo lang::get('install-php-data-write-error');
-                echo '</div>';
-            } else {
-                echo '<div class="msg success">';
-                echo lang::get('install-php-data-write-ok');
-                echo '</div>';
-            }
-            if ($errorDataWrite || $errorPHP || $errorRewrite === true) {
-                echo lang::get('install-please-check-errors');
-            } else {
-                ?>
+	if ($errorDataWrite) {
+?>
+			<div class="msg error">
+                <?= lang::get('install-php-data-write-error') ?>
+            </div>
+<?php
+	} else {
+?>
+			<div class="msg success">
+                <?= lang::get('install-php-data-write-ok') ?>
+            </div>
+<?php
+	}
+
+	if ($errorDataWrite || $errorPHP || $errorRewrite === true) {
+		echo lang::get('install-please-check-errors');
+	} else {
+?>
                 <form method="post" action="">
-                    <?php echo '<h3>'.lang::get('install-please-fill-fields').'</h3>';
-                    ?>
-                    <p><label for="lang-select"><?php echo lang::get('install-lang-choice'); ?></label>
+                    <h3><?= lang::get('install-please-fill-fields') ?></h3>
+                    <p><label for="lang-select"><?= lang::get('install-lang-choice'); ?></label>
                     <select name="lang-select" id="lang-select" onchange="langChange()">
-                        <?php
-                        foreach (lang::$availablesLocales as $k => $v) {
-                            if (lang::getLocale() === $k) {
-                                echo '<option value="' . $k . '" selected>' . $v . '</option>';
-                            } else {
-                                echo '<option value="' . $k . '">' . $v . '</option>';
-                            }
-                        }
-                        ?>
+<?php
+		$locale = lang::getLocale();
+		foreach (lang::$availablesLocales as $k => $v) {
+			$selected = ($locale === $k) ? 'selected' : '';
+?>
+						<option value="<?= $k ?>" <?= $selected ?>><?= $v  ?></option>
+<?php
+		}
+?>
                     </select>
                     </p>
                     <p>
-                        <label for="adminEmail"><?php echo lang::get('email'); ?></label><br>
+                        <label for="adminEmail"><?= lang::get('email'); ?></label><br>
                         <input type="email" name="adminEmail" required="required">
                     </p>
                     <p>
-                        <label for="adminPwd"><?php echo lang::get('password'); ?></label><br>
+                        <label for="adminPwd"><?= lang::get('password'); ?></label><br>
                         <input type="password" name="adminPwd" id="adminPwd" required="required">
                     </p>
                     <p>
-                        <a id="showPassword" href="javascript:showPassword()" class="button success"><?php echo lang::get('install-show-password'); ?></a>
-                        <button type="submit" class="button success"><?php echo lang::get('submit'); ?></button>
+                        <a id="showPassword" href="javascript:showPassword()" class="button success"><?= lang::get('install-show-password'); ?></a>
+                        <button type="submit" class="button success"><?= lang::get('submit'); ?></button>
                     </p>
-                    </form>
-                    <footer><a target="_blank" href="https://github.com/299ko/"><?php echo lang::get('site-just-using', VERSION); ?></a>
-                    </footer>
-
-                <?php
-            }
-            ?>
+				</form>
+				<footer>
+					<a target="github" href="https://github.com/299ko/"><?= lang::get('site-just-using', VERSION); ?></a>
+				</footer>
+<?php
+	}
+?>
         </section>
         <script type="text/javascript">
             function showPassword() {
-                document.getElementById("adminPwd").setAttribute("type", "text");
-                document.getElementById("showPassword").style.display = 'none';
+                document.getElementById('adminPwd').setAttribute('type', 'text');
+                document.getElementById('showPassword').style.display = 'none';
             }
             function langChange() {
-                window.location.href = '<?php echo $url; ?>?lang=' + document.getElementById("lang-select").value;
+                window.location.href = '<?= $url; ?>?lang=' + document.getElementById("lang-select").value;
             }
         </script>
     </body>

--- a/plugin/antispam/antispam.php
+++ b/plugin/antispam/antispam.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 ## Fonction d'installation
 

--- a/plugin/antispam/controllers/AntispamAdminController.php
+++ b/plugin/antispam/controllers/AntispamAdminController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class AntispamAdminController extends AdminController
 {

--- a/plugin/antispam/param/routes.php
+++ b/plugin/antispam/param/routes.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 $router = router::getInstance();
 

--- a/plugin/blog/blog.php
+++ b/plugin/blog/blog.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 require_once PLUGINS . 'blog/entities/news.php';
 require_once PLUGINS . 'blog/entities/newsComment.php';

--- a/plugin/blog/controllers/BlogAdminCategoriesController.php
+++ b/plugin/blog/controllers/BlogAdminCategoriesController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class BlogAdminCategoriesController extends AdminController {
 

--- a/plugin/blog/controllers/BlogAdminCommentsController.php
+++ b/plugin/blog/controllers/BlogAdminCommentsController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class BlogAdminCommentsController extends AdminController {
 

--- a/plugin/blog/controllers/BlogAdminConfigController.php
+++ b/plugin/blog/controllers/BlogAdminConfigController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class BlogAdminConfigController extends AdminController {
 

--- a/plugin/blog/controllers/BlogAdminPostsController.php
+++ b/plugin/blog/controllers/BlogAdminPostsController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class BlogAdminPostsController extends AdminController
 {

--- a/plugin/blog/controllers/BlogListController.php
+++ b/plugin/blog/controllers/BlogListController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit ('No direct script access allowed');
+defined('ROOT') or exit ('Access denied!');
 
 class BlogListController extends PublicController
 {

--- a/plugin/blog/controllers/BlogReadController.php
+++ b/plugin/blog/controllers/BlogReadController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class BlogReadController extends PublicController
 {

--- a/plugin/blog/entities/BlogCategoriesManager.php
+++ b/plugin/blog/entities/BlogCategoriesManager.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class BlogCategoriesManager extends CategoriesManager {
 

--- a/plugin/blog/entities/BlogCategory.php
+++ b/plugin/blog/entities/BlogCategory.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class BlogCategory extends Category {
 

--- a/plugin/blog/entities/news.php
+++ b/plugin/blog/entities/news.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class news
 {

--- a/plugin/blog/entities/newsComment.php
+++ b/plugin/blog/entities/newsComment.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class newsComment
 {

--- a/plugin/blog/entities/newsManager.php
+++ b/plugin/blog/entities/newsManager.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class newsManager {
 

--- a/plugin/blog/param/routes.php
+++ b/plugin/blog/param/routes.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 $router = router::getInstance();
 

--- a/plugin/configmanager/configmanager.php
+++ b/plugin/configmanager/configmanager.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 require_once PLUGINS . 'configmanager/lib/UpdaterManager.php';
 

--- a/plugin/configmanager/controllers/ConfigManagerAdminController.php
+++ b/plugin/configmanager/controllers/ConfigManagerAdminController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class ConfigManagerAdminController extends AdminController {
     

--- a/plugin/configmanager/controllers/ConfigManagerUpdateController.php
+++ b/plugin/configmanager/controllers/ConfigManagerUpdateController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class ConfigManagerUpdateController extends AdminController {
 

--- a/plugin/configmanager/lib/UpdaterManager.php
+++ b/plugin/configmanager/lib/UpdaterManager.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class UpdaterManager {
 

--- a/plugin/configmanager/param/routes.php
+++ b/plugin/configmanager/param/routes.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 $router = router::getInstance();
 

--- a/plugin/contact/controllers/ContactAdminController.php
+++ b/plugin/contact/controllers/ContactAdminController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class ContactAdminController extends AdminController {
 

--- a/plugin/contact/controllers/ContactController.php
+++ b/plugin/contact/controllers/ContactController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class ContactController extends PublicController
 {

--- a/plugin/contact/param/routes.php
+++ b/plugin/contact/param/routes.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 $router = router::getInstance();
 

--- a/plugin/filemanager/controllers/FileManagerAPIController.php
+++ b/plugin/filemanager/controllers/FileManagerAPIController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class FileManagerAPIController extends AdminController {
 

--- a/plugin/filemanager/filemanager.php
+++ b/plugin/filemanager/filemanager.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 require_once(PLUGINS . 'filemanager/lib/FileManager.php');
 

--- a/plugin/filemanager/lib/File.php
+++ b/plugin/filemanager/lib/File.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class File {
     

--- a/plugin/filemanager/lib/FileManager.php
+++ b/plugin/filemanager/lib/FileManager.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 require_once(PLUGINS . 'filemanager/lib/File.php');
 require_once(PLUGINS . 'filemanager/lib/Folder.php');

--- a/plugin/filemanager/lib/Folder.php
+++ b/plugin/filemanager/lib/Folder.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class Folder {
     

--- a/plugin/filemanager/param/routes.php
+++ b/plugin/filemanager/param/routes.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 $router = router::getInstance();
 

--- a/plugin/galerie/controllers/GalerieAdminController.php
+++ b/plugin/galerie/controllers/GalerieAdminController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class GalerieAdminController extends AdminController
 {

--- a/plugin/galerie/controllers/GalerieController.php
+++ b/plugin/galerie/controllers/GalerieController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class GalerieController extends PublicController
 {

--- a/plugin/galerie/galerie.php
+++ b/plugin/galerie/galerie.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 ## Fonction d'installation
 

--- a/plugin/galerie/param/routes.php
+++ b/plugin/galerie/param/routes.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 $router = router::getInstance();
 

--- a/plugin/page/controllers/PageAdminController.php
+++ b/plugin/page/controllers/PageAdminController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class PageAdminController extends AdminController {
 

--- a/plugin/page/controllers/PageController.php
+++ b/plugin/page/controllers/PageController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class PageController extends PublicController
 {

--- a/plugin/page/page.php
+++ b/plugin/page/page.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 ## Fonction d'installation
 

--- a/plugin/page/param/routes.php
+++ b/plugin/page/param/routes.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 $router = router::getInstance();
 

--- a/plugin/pluginsmanager/controllers/PluginsManagerController.php
+++ b/plugin/pluginsmanager/controllers/PluginsManagerController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class PluginsManagerController extends AdminController
 {

--- a/plugin/pluginsmanager/param/routes.php
+++ b/plugin/pluginsmanager/param/routes.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 $router = router::getInstance();
 

--- a/plugin/pluginsmanager/pluginsmanager.php
+++ b/plugin/pluginsmanager/pluginsmanager.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 ## Fonction d'installation
 

--- a/plugin/seo/controllers/SEOAdminController.php
+++ b/plugin/seo/controllers/SEOAdminController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 class SEOAdminController extends AdminController {
     

--- a/plugin/seo/param/routes.php
+++ b/plugin/seo/param/routes.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 $router = router::getInstance();
 

--- a/plugin/seo/seo.php
+++ b/plugin/seo/seo.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 ## Fonction d'installation
 

--- a/plugin/tinymce/tinymce.php
+++ b/plugin/tinymce/tinymce.php
@@ -10,7 +10,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 ## Fonction d'installation
 

--- a/plugin/users/controllers/UsersAdminController.php
+++ b/plugin/users/controllers/UsersAdminController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class UsersAdminController extends AdminController {
 

--- a/plugin/users/controllers/UsersAdminManagementController.php
+++ b/plugin/users/controllers/UsersAdminManagementController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class UsersAdminManagementController extends AdminController {
 

--- a/plugin/users/controllers/UsersLoginController.php
+++ b/plugin/users/controllers/UsersLoginController.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class UsersLoginController extends PublicController
 {

--- a/plugin/users/entities/PasswordRecovery.php
+++ b/plugin/users/entities/PasswordRecovery.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class PasswordRecovery
 {

--- a/plugin/users/entities/User.php
+++ b/plugin/users/entities/User.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 class User implements JsonSerializable
 {

--- a/plugin/users/entities/UsersManager.php
+++ b/plugin/users/entities/UsersManager.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') or exit('No direct script access allowed');
+defined('ROOT') or exit('Access denied!');
 
 /**
  * UsersManager provides methods for user management and authentication.

--- a/plugin/users/param/routes.php
+++ b/plugin/users/param/routes.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 $router = router::getInstance();
 

--- a/plugin/users/template/usersadd.tpl
+++ b/plugin/users/template/usersadd.tpl
@@ -5,7 +5,7 @@
 		<label for="email">{{ Lang.users-mail}}</label>
 		<input type="email" id="email" name="email" required />
 		<label for="pwd">{{Lang.password}}</label>
-		<input type="text" id="pwd" name="pwd" required />
+		<input type="password" id="pwd" name="pwd" required />
 		<button>{{Lang.submit}}</button>
 	</form>
 </section>

--- a/plugin/users/template/usersedit.tpl
+++ b/plugin/users/template/usersedit.tpl
@@ -6,7 +6,7 @@
 		<label for="email">{{ Lang.users-mail}}</label>
 		<input type="email" id="email" name="email" value="{{user.email}}" required />
 		<label for="pwd">{{Lang.password}}</label>
-		<input type="text" id="pwd" name="pwd" />
+		<input type="password" id="pwd" name="pwd" />
 		<button>{{Lang.submit}}</button>
 	</form>
 </section>

--- a/plugin/users/users.php
+++ b/plugin/users/users.php
@@ -7,7 +7,7 @@
  * 
  * @package 299Ko https://github.com/299Ko/299ko
  */
-defined('ROOT') OR exit('No direct script access allowed');
+defined('ROOT') OR exit('Access denied!');
 
 require_once PLUGINS . 'users/entities/User.php';
 require_once PLUGINS . 'users/entities/UsersManager.php';

--- a/theme/default/functions.php
+++ b/theme/default/functions.php
@@ -1,3 +1,3 @@
 <?php
 ## Code php du thème...
-?>
+


### PR DESCRIPTION
Si _$_SERVER['DOCUMENT_ROOT]_ est un lien virtuel, la valeur calculée avec \_\__DIR\_\__ pour _BASE_PATH_ est erronée.
Le calcul  à partir de _$\_SERVER['SCRIPT\_NAME']_ évite cet écueil

Sous Debian, seul le dossier _data_ a besoin d'être la propriété de _www-data_. Les autres dossiers peuvent être possédés par _root_ par exemple. Et _www-data_ n'a pas besoin de droits en écriture sur ces dossiers.  Il est inutile de  changer les droits sur _common/core.class.php_ dans _core::install()_.

Il est préférable d'utiliser, autant que possible, _const_ au lieu de _define()_ . la constante définie par _const_ est calculée à la compilation du script PHP. Tandis qu'une constante définie par _define()_ est évaluée à chaque exécution. C'est surtout important pour le fichier _config.php_.

Il y a une correction pour réduire la sidebar dans le back-office

Utiliser _filter_var()_ pour vérifier les adresses email valides

Remplacer &lt;?php echo $value ?&gt; par &lt;?= $value ?&gt;

Voila pour ma modeste contribution